### PR TITLE
fix: zombie check-ins

### DIFF
--- a/client/src/app/checkout/page.tsx
+++ b/client/src/app/checkout/page.tsx
@@ -1,55 +1,46 @@
 "use client";
 
 import axios from "axios";
-import { useEffect, useState } from "react";
-import { TbLogout } from "react-icons/tb";
+import { useEffect } from "react";
 import RequireAuth from "../components/RequireAuth";
 import { useAuth } from "../context/AuthContext";
-import { Info } from "../checkin/page";
-import { formatExpiration } from "../lib/time";
+import { Info, INFO_KEY } from "../stale/page";
+import { useRouter } from "next/navigation";
 
 export default function CheckOut() {
   const { user } = useAuth();
-  const [isNewTab, setIsNewTab] = useState<boolean>(true);
-  const [checkoutTime, setCheckoutTime] = useState<string | null>(null);
+  const router = useRouter();
+
+  function setInfo() {
+    const info: Info = {
+      action: "checkout",
+      header: `See you later, ${user?.displayName}!`,
+      message: `You've been removed from the roster.\nThis tab is now stale.`,
+    };
+    sessionStorage.setItem(INFO_KEY, JSON.stringify(info));
+  }
+
+  function checkOut() {
+    if (!user) return;
+    const url = `${process.env.NEXT_PUBLIC_SERVER_URL}/checkout`;
+    axios.post(url, { id: user.displayName });
+  }
 
   useEffect(() => {
-    const reqSent = sessionStorage.getItem("checkout_request_sent");
-    if (reqSent) setIsNewTab(false);
-    if (user && !reqSent) {
-      const url = `${process.env.NEXT_PUBLIC_SERVER_URL}/checkout`;
-      axios.post(url, { id: user.displayName });
-      sessionStorage.setItem("checkout_time_iso", new Date().toISOString());
-      sessionStorage.setItem("checkout_request_sent", "true");
-    }
-
-    setCheckoutTime(sessionStorage.getItem("checkout_time_iso"));
+    if (!user) return;
+    checkOut();
+    setInfo();
+    router.push("/stale");
   }, [user]);
-
-  const infochart: Info[] = [
-    {
-      condition: !isNewTab,
-      header: "Stale Tab",
-      message:
-        (checkoutTime && `Checked out at ${formatExpiration(checkoutTime)}\n`) +
-        "Tap again or open a new tab!",
-    },
-    {
-      condition: Boolean(user),
-      header: `See you later, ${user?.displayName}!`,
-      message: "You've been removed from the roster.\nCome back soon!",
-    },
-    { condition: true, header: "Loading..." },
-  ];
-  const info = infochart.find((e) => e.condition);
 
   return (
     <RequireAuth>
       <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4 text-black">
         <div className="bg-white rounded-2xl shadow-md p-8 flex flex-col items-center gap-6 w-full max-w-md text-center">
-          <TbLogout className="w-24 h-24 text-red-500" />
-          <h1 className="text-2xl font-semibold">{info?.header}</h1>
-          <p className="text-gray-600 whitespace-pre-line">{info?.message}</p>
+          <h1 className="text-2xl font-semibold">Checking you out...</h1>
+          <p className="text-gray-600 whitespace-pre-line">
+            You will be redirected.
+          </p>
         </div>
       </div>
     </RequireAuth>

--- a/client/src/app/stale/page.tsx
+++ b/client/src/app/stale/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { TbInfoHexagonFilled, TbLogin, TbLogout } from "react-icons/tb";
+import RequireAuth from "../components/RequireAuth";
+import { ReactNode, useEffect, useState } from "react";
+
+export type Info = {
+  action: "checkin" | "checkout" | "info";
+  header: string;
+  message?: string;
+};
+
+export const INFO_KEY = "info";
+
+const DEFAULT_INFO: string = JSON.stringify({
+  action: "info",
+  header: "Stale Tab",
+  message: "Tap again or use a new tab!",
+});
+
+const ICONS: Record<Info["action"], ReactNode> = {
+  checkin: <TbLogin className="w-24 h-24 text-green-600" />,
+  checkout: <TbLogout className="w-24 h-24 text-red-500" />,
+  info: <TbInfoHexagonFilled className="w-18 h-18 text-stone-500" />,
+};
+
+export default function Stale() {
+  const [info, setInfo] = useState<Info>(JSON.parse(DEFAULT_INFO));
+
+  useEffect(() => {
+    const storedInfo = sessionStorage.getItem(INFO_KEY);
+    if (storedInfo) {
+      setInfo(JSON.parse(storedInfo));
+    }
+  }, []);
+
+  const { header, message, action } = info;
+
+  return (
+    <RequireAuth>
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4 text-black">
+        <div className="bg-white rounded-2xl shadow-md p-8 flex flex-col items-center gap-6 w-full max-w-md text-center">
+          {ICONS[action]}
+          <h1 className="text-2xl font-semibold">{header}</h1>
+          <p className="text-gray-600 whitespace-pre-line">{message}</p>
+        </div>
+      </div>
+    </RequireAuth>
+  );
+}


### PR DESCRIPTION
**The Problem**
- Whenever a user taps an NFC tag, it creates a new browser tab, which checks them in. After inactivity, browsers put tabs in a dormant mode to conserve system resources. When the user opens the browser again, the tab is reloaded.
- To prevent this reload from triggering a false check-in, I previously made the app store a key in sessionStorage at time of checkin/checkout. Upon reload, the app would look for this key and stop itself from executing a check-in if it was found.
- Turns out sessionStorage's persistence is unreliable in mobile browsers; it gets wiped when the browser is closed or swiped away in "running apps", leaving the user vulnerable to a fake check-in upon re-opening the browser.

**The Solution**
Instead of the sessionStorage method, I made the check-in and check-out pages:
1. Initiate the check-in and call the API.
2. Store its messages to the user (Ex. "You are checked in until 10pm!") in sessionStorage
3. Navigate to a dummy route `/stale` where the route reads and displays the message from sessionStorage
4. If this tab were ever to refresh, it would refresh into the `/stale` tab, where there is no logic that can trigger an API call.